### PR TITLE
Refactor Azure param validation

### DIFF
--- a/src/services/__tests__/azureService.test.ts
+++ b/src/services/__tests__/azureService.test.ts
@@ -262,6 +262,25 @@ describe('AzureService', () => {
     });
   });
 
+  describe('restartAppService', () => {
+    it('should call restart on the client', async () => {
+      const mockRestart = jest.fn();
+      (service as any).getWebSiteClient = jest.fn(() => ({
+        webApps: { restart: mockRestart },
+      }));
+
+      await service.restartAppService('sub', 'rg', 'site');
+
+      expect(mockRestart).toHaveBeenCalledWith('rg', 'site');
+    });
+
+    it('should validate required parameters', async () => {
+      await expect(service.restartAppService('', 'rg', 'site')).rejects.toThrow(
+        'All parameters are required'
+      );
+    });
+  });
+
   describe('edge and negative cases', () => {
     it('should throw on invalid method calls', async () => {
       // @ts-expect-error: purposely calling with no args

--- a/src/services/azureService.ts
+++ b/src/services/azureService.ts
@@ -100,10 +100,13 @@ export class AzureService {
 
   private validateRequiredParams(
     params: Record<string, unknown>,
-    message: string
+    message: string,
+    allowEmptyStrings: boolean = false
   ): void {
     if (
-      Object.values(params).some(v => v === undefined || v === null || v === '')
+      Object.values(params).some(
+        v => v === undefined || v === null || (!allowEmptyStrings && v === '')
+      )
     ) {
       throw new AzureApiError(message, 400, 'INVALID_INPUT');
     }

--- a/src/services/azureService.ts
+++ b/src/services/azureService.ts
@@ -98,6 +98,17 @@ export class AzureService {
     this.credential = new ExistingTokenCredential(accessToken);
   }
 
+  private validateRequiredParams(
+    params: Record<string, unknown>,
+    message: string
+  ): void {
+    if (
+      Object.values(params).some(v => v === undefined || v === null || v === '')
+    ) {
+      throw new AzureApiError(message, 400, 'INVALID_INPUT');
+    }
+  }
+
   /**
    * Get or create a WebSiteManagementClient for a subscription
    */
@@ -162,13 +173,10 @@ export class AzureService {
    * Fetch all App Services and Function Apps in a subscription
    */
   async getAppServices(subscriptionId: string): Promise<AzureAppService[]> {
-    if (!subscriptionId) {
-      throw new AzureApiError(
-        'Subscription ID is required',
-        400,
-        'INVALID_INPUT'
-      );
-    }
+    this.validateRequiredParams(
+      { subscriptionId },
+      'Subscription ID is required'
+    );
 
     try {
       const client = this.getWebSiteClient(subscriptionId);
@@ -198,13 +206,10 @@ export class AzureService {
     subscriptionId: string,
     resourceGroupName: string
   ): Promise<AzureAppService[]> {
-    if (!subscriptionId || !resourceGroupName) {
-      throw new AzureApiError(
-        'Both subscription ID and resource group name are required',
-        400,
-        'INVALID_INPUT'
-      );
-    }
+    this.validateRequiredParams(
+      { subscriptionId, resourceGroupName },
+      'Both subscription ID and resource group name are required'
+    );
 
     try {
       const client = this.getWebSiteClient(subscriptionId);
@@ -237,13 +242,10 @@ export class AzureService {
     resourceGroupName: string,
     siteName: string
   ): Promise<AzureAppService> {
-    if (!subscriptionId || !resourceGroupName || !siteName) {
-      throw new AzureApiError(
-        'All parameters are required',
-        400,
-        'INVALID_INPUT'
-      );
-    }
+    this.validateRequiredParams(
+      { subscriptionId, resourceGroupName, siteName },
+      'All parameters are required'
+    );
 
     try {
       const client = this.getWebSiteClient(subscriptionId);
@@ -348,12 +350,18 @@ export class AzureService {
     templateUri: string,
     parameters: DeploymentParameters
   ): Promise<unknown> {
+    this.validateRequiredParams(
+      {
+        subscriptionId,
+        resourceGroupName,
+        deploymentName,
+        templateUri,
+        parameters,
+      },
+      'All deployment parameters are required'
+    );
+
     if (
-      !subscriptionId ||
-      !resourceGroupName ||
-      !deploymentName ||
-      !templateUri ||
-      !parameters ||
       typeof parameters.siteName === 'undefined' ||
       typeof parameters.location === 'undefined' ||
       typeof parameters.ddApiKey === 'undefined' ||
@@ -382,13 +390,10 @@ export class AzureService {
     resourceGroupName: string,
     deploymentName: string
   ): Promise<unknown> {
-    if (!subscriptionId || !resourceGroupName || !deploymentName) {
-      throw new AzureApiError(
-        'All parameters are required',
-        400,
-        'INVALID_INPUT'
-      );
-    }
+    this.validateRequiredParams(
+      { subscriptionId, resourceGroupName, deploymentName },
+      'All parameters are required'
+    );
 
     // This method is now handled by the ARM client, but we keep the interface
     // For now, we'll just return a placeholder or throw an error if not implemented
@@ -408,13 +413,10 @@ export class AzureService {
   async getResourceGroups(
     subscriptionId: string
   ): Promise<AzureResourceGroup[]> {
-    if (!subscriptionId) {
-      throw new AzureApiError(
-        'Subscription ID is required',
-        400,
-        'INVALID_INPUT'
-      );
-    }
+    this.validateRequiredParams(
+      { subscriptionId },
+      'Subscription ID is required'
+    );
 
     try {
       const client = this.getResourceClient(subscriptionId);
@@ -443,13 +445,10 @@ export class AzureService {
     resourceGroupName: string,
     planName: string
   ): Promise<AppServicePlan> {
-    if (!subscriptionId || !resourceGroupName || !planName) {
-      throw new AzureApiError(
-        'All parameters are required',
-        400,
-        'INVALID_INPUT'
-      );
-    }
+    this.validateRequiredParams(
+      { subscriptionId, resourceGroupName, planName },
+      'All parameters are required'
+    );
 
     try {
       const client = this.getWebSiteClient(subscriptionId);
@@ -511,13 +510,10 @@ export class AzureService {
     resourceGroupName: string,
     siteName: string
   ): Promise<AppSettings> {
-    if (!subscriptionId || !resourceGroupName || !siteName) {
-      throw new AzureApiError(
-        'All parameters are required',
-        400,
-        'INVALID_INPUT'
-      );
-    }
+    this.validateRequiredParams(
+      { subscriptionId, resourceGroupName, siteName },
+      'All parameters are required'
+    );
 
     try {
       const client = this.getWebSiteClient(subscriptionId);
@@ -546,13 +542,10 @@ export class AzureService {
     siteName: string,
     settings: AppSettings
   ): Promise<void> {
-    if (!subscriptionId || !resourceGroupName || !siteName) {
-      throw new AzureApiError(
-        'All parameters are required',
-        400,
-        'INVALID_INPUT'
-      );
-    }
+    this.validateRequiredParams(
+      { subscriptionId, resourceGroupName, siteName },
+      'All parameters are required'
+    );
 
     try {
       const client = this.getWebSiteClient(subscriptionId);
@@ -660,13 +653,10 @@ export class AzureService {
       allowAccessToAllAppSettings?: boolean;
     }
   ): Promise<void> {
-    if (!subscriptionId || !resourceGroupName || !siteName) {
-      throw new AzureApiError(
-        'All parameters are required',
-        400,
-        'INVALID_INPUT'
-      );
-    }
+    this.validateRequiredParams(
+      { subscriptionId, resourceGroupName, siteName },
+      'All parameters are required'
+    );
 
     try {
       const client = this.getWebSiteClient(subscriptionId);
@@ -829,13 +819,10 @@ export class AzureService {
     resourceGroupName: string,
     siteName: string
   ): Promise<void> {
-    if (!subscriptionId || !resourceGroupName || !siteName) {
-      throw new AzureApiError(
-        'All parameters are required',
-        400,
-        'INVALID_INPUT'
-      );
-    }
+    this.validateRequiredParams(
+      { subscriptionId, resourceGroupName, siteName },
+      'All parameters are required'
+    );
 
     try {
       const client = this.getWebSiteClient(subscriptionId);
@@ -913,13 +900,10 @@ export class AzureService {
     resourceGroupName: string,
     siteName: string
   ): Promise<any> {
-    if (!subscriptionId || !resourceGroupName || !siteName) {
-      throw new AzureApiError(
-        'All parameters are required',
-        400,
-        'INVALID_INPUT'
-      );
-    }
+    this.validateRequiredParams(
+      { subscriptionId, resourceGroupName, siteName },
+      'All parameters are required'
+    );
 
     try {
       const client = this.getWebSiteClient(subscriptionId);

--- a/src/services/azureService.ts
+++ b/src/services/azureService.ts
@@ -364,6 +364,19 @@ export class AzureService {
       'All deployment parameters are required'
     );
 
+    this.validateDeploymentParameters(parameters);
+
+    // This method is now handled by the ARM client, but we keep the interface
+    // For now, we'll just return a placeholder or throw an error if not implemented
+    // as the original logic was not fully refactored.
+    // A proper implementation would involve deploying a template.
+    console.warn('deployDatadogAPM is not fully implemented with the new SDK.');
+  }
+
+  /**
+   * Validate deployment parameters for required properties
+   */
+  private validateDeploymentParameters(parameters: DeploymentParameters): void {
     if (
       typeof parameters.siteName === 'undefined' ||
       typeof parameters.location === 'undefined' ||


### PR DESCRIPTION
## Summary
- centralize parameter validation in `AzureService`
- call helper from various methods to cut down on duplication
- add unit tests for `restartAppService`

## Testing
- `yarn quality`
- `yarn test:ci` *(fails: Cannot find module '@typespec/ts-http-runtime/internal/logger')*

------
https://chatgpt.com/codex/tasks/task_b_687ebf775b808331845da7659f8dc687